### PR TITLE
Change CollectionAddress Query

### DIFF
--- a/contracts/modules/mint/src/contract.rs
+++ b/contracts/modules/mint/src/contract.rs
@@ -901,7 +901,7 @@ fn check_collection_ids_exists(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::CollectionAddress(collection_id) => {
+        QueryMsg::CollectionAddress { collection_id } => {
             to_binary(&query_collection_address(deps, collection_id)?)
         }
         QueryMsg::CollectionInfo { collection_id } => {

--- a/contracts/modules/mint/src/msg.rs
+++ b/contracts/modules/mint/src/msg.rs
@@ -127,7 +127,7 @@ pub enum QueryMsg {
     Config {},
     /// Resolve the collection address for a collection id.
     #[returns(ResponseWrapper<String>)]
-    CollectionAddress(u32),
+    CollectionAddress { collection_id: u32 },
     /// Get the collection info for a collection id.
     #[returns(ResponseWrapper<CollectionInfo>)]
     CollectionInfo { collection_id: u32 },

--- a/contracts/modules/mint/tests/integration.rs
+++ b/contracts/modules/mint/tests/integration.rs
@@ -192,7 +192,7 @@ mod actions {
                 .execute_contract(Addr::unchecked(USER), minter_addr.clone(), &msg, &[])
                 .unwrap();
 
-            let msg = QueryMsg::CollectionAddress(1);
+            let msg = QueryMsg::CollectionAddress { collection_id: 1 };
             let response: ResponseWrapper<String> =
                 app.wrap().query_wasm_smart(minter_addr, &msg).unwrap();
             let token_address = response.data;
@@ -323,7 +323,7 @@ mod actions {
                     )
                     .unwrap();
 
-                let msg = QueryMsg::CollectionAddress(1);
+                let msg = QueryMsg::CollectionAddress { collection_id: 1 };
                 let res: ResponseWrapper<String> = app
                     .wrap()
                     .query_wasm_smart(minter_addr.clone(), &msg)
@@ -519,7 +519,7 @@ mod actions {
 
                 setup_collection(&mut app, &minter_addr, Addr::unchecked(USER), None);
 
-                let msg = QueryMsg::CollectionAddress(1);
+                let msg = QueryMsg::CollectionAddress { collection_id: 1 };
                 let res: ResponseWrapper<String> =
                     app.wrap().query_wasm_smart(minter_addr, &msg).unwrap();
                 assert_eq!(res.data, "contract1");


### PR DESCRIPTION
This PR updates the `CollectionAddress` query message in mint module to accept `collection_id` param.