### PR TITLE
Save sender's address as an operator on hub creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- On Hub Module instantiation, `info.sender` is now saved as an operator for the contract. ([#73])(https://github.com/KompleTeam/komple-framework/pull/73)
+
 ## [1.1.0-beta] - 2023-02-14
 
 ### Added

--- a/contracts/modules/hub/src/contract.rs
+++ b/contracts/modules/hub/src/contract.rs
@@ -35,7 +35,7 @@ const MAX_DESCRIPTION_LENGTH: u32 = 512;
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
-    _info: MessageInfo,
+    info: MessageInfo,
     msg: RegisterMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
@@ -47,8 +47,10 @@ pub fn instantiate(
     let data: InstantiateMsg = from_binary(&msg.data.unwrap())?;
 
     let admin = deps.api.addr_validate(&msg.admin)?;
-    let config = Config { admin };
+    let config = Config { admin: admin.clone() };
     CONFIG.save(deps.storage, &config)?;
+
+    OPERATORS.save(deps.storage, &vec![info.sender])?;
 
     if data.hub_info.description.len() > MAX_DESCRIPTION_LENGTH as usize {
         return Err(ContractError::DescriptionTooLong {});


### PR DESCRIPTION
When using external contracts to orchestrate Hub Module creation, sender address needs to have admin privileges if any other action wants to be done on the contract.

This PR adds this support so that the controller/factory/orchestrator contract can execute other actions on Hub Module.